### PR TITLE
link to libFLAC/ogg statically for osx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,12 +8,13 @@ enable_language(CXX)
 
 find_package(xbmc REQUIRED)
 find_package(FLAC REQUIRED)
+find_package(Ogg REQUIRED)
 
 include_directories(${XBMC_INCLUDE_DIR}
                     ${FLAC_INCLUDE_DIRS})
 
 set(FLAC_SOURCES src/EncoderFlac.cpp)
 
-set(DEPLIBS ${FLAC_LIBRARIES})
+set(DEPLIBS ${FLAC_LIBRARIES} ${OGG_LIBRARIES})
 
 build_addon(audioencoder.flac FLAC DEPLIBS)

--- a/FindOgg.cmake
+++ b/FindOgg.cmake
@@ -1,0 +1,22 @@
+# - Try to find ogg
+# Once done this will define
+#
+# OGG_FOUND - system has libogg
+# OGG_INCLUDE_DIRS - the libogg include directory
+# OGG_LIBRARIES - The libogg libraries
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules (OGG ogg)
+  list(APPEND OGG_INCLUDE_DIRS ${OGG_INCLUDEDIR})
+endif()
+
+if(NOT OGG_FOUND)
+  find_path(OGG_INCLUDE_DIRS ogg/ogg.h)
+  find_library(OGG_LIBRARIES ogg)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Ogg DEFAULT_MSG OGG_INCLUDE_DIRS OGG_LIBRARIES)
+
+mark_as_advanced(OGG_INCLUDE_DIRS OGG_LIBRARIES)


### PR DESCRIPTION
Not sure if this is the best way to be doing this.  ATM we're dynamically linking to flac+ogg, which probably isn't what we want given that these aren't distributed with XBMC any longer, at least if we're going to be distributing the binary add-ons separately.

I take no credit for the .a magic - that's @wsnipex.

@notspiff any comments/suggestions most welcome.  The static linking may well only be appropriate for lesser platforms?

(EDIT: lesser == static)
